### PR TITLE
Refine snack tone for automatic clothing system

### DIFF
--- a/src/content/snacks/003-automatic-clothing-system.mdx
+++ b/src/content/snacks/003-automatic-clothing-system.mdx
@@ -1,0 +1,20 @@
+---
+layout: "@/layouts/SnackLayout.astro"
+title: "I want an automatic clothing system"
+description: "A wardrobe that washes, dries, rotates wear evenly, and presents outfits based on preselected styles or where I am going"
+tags:
+  - wardrobe
+  - automation
+  - clothing
+  - style
+published: true
+releaseDate: 2026-01-10
+---
+
+I want an automatic clothing system that handles washing, cleaning, drying, and then presents clothes ready to wear.
+
+Also: equal wear. Every piece should get used the same amount so nothing gets worn out faster than the rest.
+
+Then I should be able to pick from a few preselected matching styles, tap one, and the cabin opens with the right items.
+
+Or I can just input where I am going and what I need to do, and it figures the outfit out for me.


### PR DESCRIPTION
### Motivation
- Make the snack copy sound more casual and like natural writing rather than an "AI-styled" explanation.
- Keep the core idea of an automatic clothing system that washes, dries, rotates wear evenly, and serves outfits based on style presets or destination input.
- Add a short, publishable snack entry that fits the existing content format and tone.

### Description
- Add `src/content/snacks/003-automatic-clothing-system.mdx` with frontmatter including `layout: "@/layouts/SnackLayout.astro"`, `title`, `description`, `tags`, `published: true`, and `releaseDate`.
- Replace the original copy with a more casual, direct version that highlights washing/cleaning/drying, an "Also: equal wear" line, style presets, and destination-based outfit suggestions.
- Keep the file content concise and aligned with the site's snack format.

### Testing
- No automated tests were run because this is a content-only change.
- No site build was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e3fd673948327974d960c605fd8b6)